### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,7 @@ A tailor made implementation of algolia instantsearch for nuxt 3.
 1. Add `@atoms-studio/nuxt-swiftsearch` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D @atoms-studio/nuxt-swiftsearch
-
-# Using yarn
-yarn add --dev @atoms-studio/nuxt-swiftsearch
-
-# Using npm
-npm install --save-dev @atoms-studio/nuxt-swiftsearch
-
-# Using bun
-bun add -D @atoms-studio/nuxt-swiftsearch
+npx nuxi@latest module add swiftsearch
 ```
 
 2. Add `@atoms-studio/nuxt-swiftsearch` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -7,17 +7,7 @@ title: Installation
 1. Add `@atoms-studio/nuxt-swiftsearch` dependency to your project
 
 ```bash [Terminal]
-# Using pnpm
-pnpm add -D @atoms-studio/nuxt-swiftsearch
-
-# Using yarn
-yarn add --dev @atoms-studio/nuxt-swiftsearch
-
-# Using npm
-npm install --save-dev @atoms-studio/nuxt-swiftsearch
-
-# Using bun
-bun add -D @atoms-studio/nuxt-swiftsearch
+npx nuxi@latest module add swiftsearch
 ```
 
 2. Add `@atoms-studio/nuxt-swiftsearch` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/index.yml
+++ b/docs/content/index.yml
@@ -18,16 +18,16 @@ hero:
   code: |
     ```bash [Terminal]
     # Using pnpm
-    pnpm add -D @atoms-studio/nuxt-swiftsearch
+    npx nuxi@latest module add swiftsearch
 
     # Using yarn
-    yarn add --dev @atoms-studio/nuxt-swiftsearch
+    npx nuxi@latest module add swiftsearch
 
     # Using npm
-    npm install --save-dev @atoms-studio/nuxt-swiftsearch
+    npx nuxi@latest module add swiftsearch
 
     # Using bun
-    bun add -D @atoms-studio/nuxt-swiftsearch
+    npx nuxi@latest module add swiftsearch
     ```
 features:
   items:

--- a/docs/content/index.yml
+++ b/docs/content/index.yml
@@ -17,16 +17,6 @@ hero:
       size: lg
   code: |
     ```bash [Terminal]
-    # Using pnpm
-    npx nuxi@latest module add swiftsearch
-
-    # Using yarn
-    npx nuxi@latest module add swiftsearch
-
-    # Using npm
-    npx nuxi@latest module add swiftsearch
-
-    # Using bun
     npx nuxi@latest module add swiftsearch
     ```
 features:


### PR DESCRIPTION
This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
<!-- GitContextStart -->
- - -
This pull request can be reviewed on [<img src="https://gitcontext.com/logo/GitContextButton.svg" height="32" align="absmiddle" alt="GitContext.com"/>](https://gitcontext.com/app/prs/github/atoms-studio/nuxt-swiftsearch/3)
<!-- GitContextEnd -->