### PR TITLE
fix: correct default currentRefinement values and max placeholder in …

### DIFF
--- a/src/runtime/components/RangeInput.vue
+++ b/src/runtime/components/RangeInput.vue
@@ -9,7 +9,7 @@ const props = withDefaults(
     attribute: string;
     precision?: number;
   }>(),
-  { precision: 1 },
+  { precision: 1 }
 );
 
 const { state: rangesState } = useAisWidget("range");
@@ -31,8 +31,8 @@ const values = computed(() => {
   const [minValue, maxValue] = state.value.start;
   const { min: minRange, max: maxRange } = state.value.range;
   return {
-    min: minValue !== -Infinity && minValue !== minRange ? minValue : minRange,
-    max: maxValue !== Infinity && maxValue !== maxRange ? maxValue : maxRange,
+    min: minValue !== -Infinity && minValue !== minRange ? minValue : undefined,
+    max: maxValue !== Infinity && maxValue !== maxRange ? maxValue : undefined,
   };
 });
 
@@ -65,8 +65,8 @@ const refine = (data: { min: number | undefined; max: number | undefined }) => {
           :class="suit('form')"
           @submit.prevent="
             refine({
-              min: pick(minInput, state.range.min),
-              max: pick(maxInput, state.range.max),
+              min: pick(minInput, values.min),
+              max: pick(maxInput, values.max),
             })
           "
         >
@@ -100,7 +100,7 @@ const refine = (data: { min: number | undefined; max: number | undefined }) => {
               :step="step"
               :min="state.range.min"
               :max="state.range.max"
-              :placeholder="state.range?.min?.toString()"
+              :placeholder="state.range?.max?.toString()"
               :value="values.max"
               label
               @change="


### PR DESCRIPTION
…AisRangeInput


The `currentRefinement` values should remain unset if not explicitly defined by the user. Currently, it is automatically initialized with `minRange` and `maxRange`, which can lead to unintended behavior.

This PR also includes a fix for the `max` input placeholder to display the correct value :)

Reference: https://github.com/algolia/instantsearch/blob/master/packages/vue-instantsearch/src/components/RangeInput.vue