### PR TITLE
Problems NuxtLink object and not url

### DIFF
--- a/playground/components/SearchExperience.vue
+++ b/playground/components/SearchExperience.vue
@@ -1,5 +1,16 @@
 <template>
   <div>
+    <NuxtLink :to="{
+      name: 'brand',
+      query: {
+        'refinementList[brand][0]': 'Samsung',
+      },
+      params: {
+        brand: 'Samsung',
+      },
+    }">GO TO BRAND FILTERED</NuxtLink>
+
+    <NuxtLink to="/Samsung?refinementList%5Bbrand%5D%5B0%5D=Samsung">GO TO BRAND FILTERED LINK</NuxtLink>
     <AisInstantSearch
       :widgets
       :configuration

--- a/playground/components/SearchExperience.vue
+++ b/playground/components/SearchExperience.vue
@@ -8,9 +8,9 @@
       params: {
         brand: 'Samsung',
       },
-    }">GO TO BRAND FILTERED</NuxtLink>
+    }">TEST QUERY OBJECT</NuxtLink>
 
-    <NuxtLink to="/Samsung?refinementList%5Bbrand%5D%5B0%5D=Samsung">GO TO BRAND FILTERED LINK</NuxtLink>
+    <NuxtLink to="/Samsung?refinementList%5Bbrand%5D%5B0%5D=Samsung">TEST QUERY URL</NuxtLink>
     <AisInstantSearch
       :widgets
       :configuration

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -3,7 +3,7 @@
     <NuxtLink
       to="/?instant_search%5Btoggle%5D%5Bfree_shipping%5D=true&instant_search%5Bquery%5D=testa"
     >
-      Test query
+      Test query URL
     </NuxtLink>
     <br />
     <NuxtLink to="/Samsung"> Go to brand </NuxtLink>
@@ -18,7 +18,7 @@
         'instant_search[refinementList][brand][0]': 'Apple',
         'instant_search[refinementList][brand][1]': 'Pelican'
       }
-    }"> Go to brand route name</NuxtLink>
+    }"> Test query OBJECT</NuxtLink>
 
     <AisInstantSearch :widgets :configuration :middlewares instance-key="index">
       <AisStats />
@@ -31,7 +31,7 @@
       <AisToggleRefinement attribute="free_shipping" />
       <AisInfiniteHits />
       <AisRefinementList attribute="brand" searchable />
-      <!-- <AisIndex index="airbnb">
+      <AisIndex index="airbnb">
         <AisInfiniteHits>
           <template #item="{ item }">
             {{ item.city }}
@@ -39,7 +39,7 @@
         </AisInfiniteHits>
         <AisRefinementList attribute="city" />
         <AisClearRefinements id="bnb" />
-      </AisIndex> -->
+      </AisIndex>
     </AisInstantSearch>
   </div>
 </template>
@@ -51,15 +51,15 @@ import type { Middleware } from "instantsearch.js";
 const client = algoliasearch("latency", "6be0576ff61c053d5f9a3225e2a90f76", {});
 const algoliaRouter = useAisRouter();
 
-// const indexBnb = useAisIndex({
-//   indexName: "airbnb",
-// });
+const indexBnb = useAisIndex({
+  indexName: "airbnb",
+});
 
-// indexBnb.addWidgets([
-//   useAisInfiniteHits({}),
-//   useAisClearRefinements({}, "bnb"),
-//   useAisRefinementList({ attribute: "city" }),
-// ]);
+indexBnb.addWidgets([
+  useAisInfiniteHits({}),
+  useAisClearRefinements({}, "bnb"),
+  useAisRefinementList({ attribute: "city" }),
+]);
 
 const widgets = computed(() => [
   useAisSortBy({
@@ -91,14 +91,14 @@ const widgets = computed(() => [
     attribute: "price",
   }),
   useAisConfigure({ searchParameters: {} }),
-  // indexBnb,
+  indexBnb,
 ]);
 
 const middlewares = ref<Middleware[]>([
   ({ instantSearchInstance }) => {
     return {
       onStateChange({ uiState }) {
-        // console.log(uiState, "from middleware");
+        console.log(uiState, "from middleware");
       },
       subscribe() {},
       unsubscribe() {},

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -8,6 +8,14 @@
     <NuxtLink to="/Samsung"> Go to brand </NuxtLink>
     <NuxtLink to="/test/Samsung"> Go to brand catchall </NuxtLink>
 
+    <NuxtLink :to="{
+      name: 'index',
+      query: {
+        'instant_search[toggle][free_shipping]': true,
+        'instant_search[refinementList][brand][0]': 'Apple'
+      }
+    }"> Go to brand route name</NuxtLink>
+
     <AisInstantSearch :widgets :configuration :middlewares instance-key="index">
       <AisStats />
       <AisClearRefinements id="free_shipping" />
@@ -19,7 +27,7 @@
       <AisToggleRefinement attribute="free_shipping" />
       <AisInfiniteHits />
       <AisRefinementList attribute="brand" searchable />
-      <AisIndex index="airbnb">
+      <!-- <AisIndex index="airbnb">
         <AisInfiniteHits>
           <template #item="{ item }">
             {{ item.city }}
@@ -27,7 +35,7 @@
         </AisInfiniteHits>
         <AisRefinementList attribute="city" />
         <AisClearRefinements id="bnb" />
-      </AisIndex>
+      </AisIndex> -->
     </AisInstantSearch>
   </div>
 </template>
@@ -39,15 +47,15 @@ import type { Middleware } from "instantsearch.js";
 const client = algoliasearch("latency", "6be0576ff61c053d5f9a3225e2a90f76", {});
 const algoliaRouter = useAisRouter();
 
-const indexBnb = useAisIndex({
-  indexName: "airbnb",
-});
+// const indexBnb = useAisIndex({
+//   indexName: "airbnb",
+// });
 
-indexBnb.addWidgets([
-  useAisInfiniteHits({}),
-  useAisClearRefinements({}, "bnb"),
-  useAisRefinementList({ attribute: "city" }),
-]);
+// indexBnb.addWidgets([
+//   useAisInfiniteHits({}),
+//   useAisClearRefinements({}, "bnb"),
+//   useAisRefinementList({ attribute: "city" }),
+// ]);
 
 const widgets = computed(() => [
   useAisSortBy({
@@ -79,7 +87,7 @@ const widgets = computed(() => [
     attribute: "price",
   }),
   useAisConfigure({ searchParameters: {} }),
-  indexBnb,
+  // indexBnb,
 ]);
 
 const middlewares = ref<Middleware[]>([

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -5,14 +5,18 @@
     >
       Test query
     </NuxtLink>
+    <br />
     <NuxtLink to="/Samsung"> Go to brand </NuxtLink>
+    <br />
     <NuxtLink to="/test/Samsung"> Go to brand catchall </NuxtLink>
-
+    <br />
     <NuxtLink :to="{
       name: 'index',
       query: {
-        'instant_search[toggle][free_shipping]': true,
-        'instant_search[refinementList][brand][0]': 'Apple'
+        'instant_search[toggle][free_shipping]': 'true',
+        'instant_search[query]': 'testa',
+        'instant_search[refinementList][brand][0]': 'Apple',
+        'instant_search[refinementList][brand][1]': 'Pelican'
       }
     }"> Go to brand route name</NuxtLink>
 
@@ -94,7 +98,7 @@ const middlewares = ref<Middleware[]>([
   ({ instantSearchInstance }) => {
     return {
       onStateChange({ uiState }) {
-        console.log(uiState, "from middleware");
+        // console.log(uiState, "from middleware");
       },
       subscribe() {},
       unsubscribe() {},

--- a/playground/pages/test/[...catchall].vue
+++ b/playground/pages/test/[...catchall].vue
@@ -29,8 +29,8 @@
             v-for="item in items"
             :id="item.objectID"
             :key="item.objectID"
-            :name="item.name"
-            :price="item.price"
+            :name="item.name as string"
+            :price="item.price as string"
           />
         </template>
       </AisInfiniteHits>

--- a/src/runtime/composables/useAisRouter.ts
+++ b/src/runtime/composables/useAisRouter.ts
@@ -11,7 +11,7 @@ type QueryObject = {
 
 const stripUndefined = (obj: Record<string, any>) => {
   return Object.fromEntries(
-    Object.entries(obj).filter(([k, v]) => k !== 'sortBy')
+    Object.entries(obj).filter(([k, v]) => v !== undefined)
   )
 }
 

--- a/src/runtime/composables/useAisRouter.ts
+++ b/src/runtime/composables/useAisRouter.ts
@@ -63,10 +63,9 @@ export const useAisRouter = () => {
           const urlParsed = parseURL(currentRoute.fullPath)
           const queryParsed = parseQuery(urlParsed.search)
           query = convertToNestedObject(queryParsed)
-        }else {
+        } else {
           query = currentRoute.query
         }
-        console.log('query', query)
         const normalizedQuery = Array.isArray(query) ? query[0] : query;
         return stripUndefined(normalizedQuery);
       },

--- a/src/runtime/composables/useAisRouter.ts
+++ b/src/runtime/composables/useAisRouter.ts
@@ -41,14 +41,8 @@ const convertToNestedObject = (query: ParsedQuery): QueryObject => {
   return result
 }
 
-
 const containsBrackets = (obj: LocationQuery) => {
-  for (const key in obj) {
-      if (key.includes('[') || key.includes(']')) {
-          return true
-      }
-  }
-  return false
+  return Object.keys(obj).some(key => key.includes('[') || key.includes(']'))
 }
 
 export const useAisRouter = () => {

--- a/src/runtime/composables/useAisRouter.ts
+++ b/src/runtime/composables/useAisRouter.ts
@@ -12,15 +12,15 @@ function stripUndefined(obj: Record<string, any>) {
 }
 
 type QueryObject = {
-  [x:string]: string | number | string[] | boolean | QueryObject
+  [x:string]: QueryObject | string | string[] | number | boolean
 }
 
-const convertToNestedObject = (query: ParsedQuery): ParsedQuery => {
-  const result = {};
+const convertToNestedObject = (query: ParsedQuery): QueryObject => {
+  const result: QueryObject = {};
 
   Object.keys(query).forEach(key => {
       const value = query[key]
-      const keys: string[] = key.split(/[[\]]+/).filter(k => k); // Split the key and filter out empty strings
+      const keys = key.split(/[[\]]+/).filter(k => k); // Split the key and filter out empty strings
 
       let currentLevel: QueryObject = result;
 
@@ -29,8 +29,10 @@ const convertToNestedObject = (query: ParsedQuery): ParsedQuery => {
               currentLevel[k] = value;
           } else {
               if (!currentLevel[k]) {
+                // @ts-ignore
                   currentLevel[k] = isNaN(keys[index + 1]) ? {} : [];
               }
+              // @ts-ignore
               currentLevel = currentLevel[k];
           }
       });


### PR DESCRIPTION
I found a bug when i'm arriving into a listing page from a NuxtLink when the **TO** is an object and not an URL, see below the example

THIS IT WORKS
```
    <NuxtLink  to="/?instant_search%5Btoggle%5D%5Bfree_shipping%5D=true&instant_search%5Bquery%5D=testa">
      Test query URL
    </NuxtLink>
```

THIS NOT WORKS
```
    <NuxtLink :to="{
      name: 'index',
      query: {
        'instant_search[toggle][free_shipping]': 'true',
        'instant_search[query]': 'testa',
      }
    }">
Test query OBJECT
</NuxtLink>
```

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/atoms-studio/nuxt-swiftsearch/18)
<!-- GitContextEnd -->