### PR TITLE
feat: add ais-autocomplete widget

### DIFF
--- a/docs/content/3.components/16.ais-autocomplete.md
+++ b/docs/content/3.components/16.ais-autocomplete.md
@@ -1,0 +1,59 @@
+---
+title: "<AisAutocomplete>"
+description: Autocomplete Widget
+---
+
+## Usage
+
+```vue [MySearchExperience.vue]
+<template>
+  <div>
+    <AisInstantSearch :widgets :configuration>
+      <AisAutocomplete>
+        <template #default="{ currentRefinement, indices, refine }">
+          <input
+            type="search"
+            :value="currentRefinement"
+            placeholder="Search for a product"
+            @input="refine(($event.currentTarget as HTMLInputElement).value)"
+          >
+          <ul
+            v-for="index in indices"
+            :key="index.indexId"
+          >
+            <li>
+              <h3>{{ index.indexName }}</h3>
+              <ul>
+                <li
+                  v-for="hit in index.hits"
+                  :key="hit.objectID"
+                >
+                  <ais-highlight
+                    attribute="name"
+                    :hit="hit"
+                  />
+                  <button
+                    type="button"
+                    @click="index.sendEvent('click', hit, 'Item Added')"
+                  >
+                    Add to cart
+                  </button>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </template>
+      </AisAutocomplete>
+    </AisInstantSearch>
+  </div>
+</template>
+
+<script setup lang="ts">
+const widgets = computed(() => [
+  useAisAutocomplete({}),
+]);
+</script>
+```
+
+Slots, props and widget connector params are all typed!
+More thorough documentation coming soon :)

--- a/playground/pages/autocomplete.vue
+++ b/playground/pages/autocomplete.vue
@@ -1,0 +1,62 @@
+<template>
+  <div>
+    <AisInstantSearch
+      :widgets
+      :configuration
+      instance-key="autocomplete"
+    >
+      <AisAutocomplete>
+        <template #default="{ currentRefinement, indices, refine }">
+          <input
+            type="search"
+            :value="currentRefinement"
+            placeholder="Search for a product"
+            @input="refine(($event.currentTarget as HTMLInputElement).value)"
+          >
+          <ul
+            v-for="index in indices"
+            :key="index.indexId"
+          >
+            <li>
+              <h3>{{ index.indexName }}</h3>
+              <ul>
+                <li
+                  v-for="hit in index.hits"
+                  :key="hit.objectID"
+                >
+                  <ais-highlight
+                    attribute="name"
+                    :hit="hit"
+                  />
+                  <button
+                    type="button"
+                    @click="index.sendEvent('click', hit, 'Item Added')"
+                  >
+                    Add to cart
+                  </button>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </template>
+      </AisAutocomplete>
+    </AisInstantSearch>
+  </div>
+</template>
+
+<script setup lang="ts">
+import algoliasearch from "algoliasearch";
+import type { InstantSearchOptions } from "instantsearch.js/es/types";
+const client = algoliasearch("latency", "6be0576ff61c053d5f9a3225e2a90f76");
+
+const widgets = computed(() => [
+  useAisAutocomplete({})
+]);
+
+const configuration = ref<InstantSearchOptions>({
+  indexName: "instant_search",
+  searchClient: client,
+} as unknown as InstantSearchOptions);
+</script>
+
+<style scoped></style>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -7,6 +7,7 @@
     </NuxtLink>
     <NuxtLink to="/Samsung"> Go to brand </NuxtLink>
     <NuxtLink to="/test/Samsung"> Go to brand catchall </NuxtLink>
+    <NuxtLink to="/autocomplete"> Autocomplete </NuxtLink>
 
     <AisInstantSearch :widgets :configuration :middlewares instance-key="index">
       <AisStats />
@@ -15,6 +16,7 @@
       <AisClearRefinements id="all" />
       <AisRangeInput attribute="price" />
       <AisSearchBox />
+      <AisAutocomplete />
       <AisSortBy />
       <AisToggleRefinement attribute="free_shipping" />
       <AisInfiniteHits />
@@ -75,6 +77,7 @@ const widgets = computed(() => [
   }, "brand-index"),
   useAisToggleRefinement({ attribute: "free_shipping" }),
   useAisSearchBox({}),
+  useAisAutocomplete({}),
   useAisRangeInput({
     attribute: "price",
   }, "price-index"),

--- a/src/runtime/components/Autocomplete.vue
+++ b/src/runtime/components/Autocomplete.vue
@@ -1,0 +1,35 @@
+<template>
+  <div
+    v-if="state"
+    :class="suit()"
+  >
+    <slot
+      :refine="state.refine"
+      :current-refinement="state.currentRefinement"
+      :indices="state.indices"
+    >
+      <p>
+        This widget doesn't render anything without a filled in default slot.
+      </p>
+      <p>query, function to refine and results are provided.</p>
+      <pre>refine: Function</pre>
+      <pre>currentRefinement: "{{ state.currentRefinement }}"</pre>
+      <details>
+        <summary><code>indices</code>:</summary>
+        <pre>{{ state.indices }}</pre>
+      </details>
+    </slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAisWidget } from "../composables/useAisWidget";
+import { useSuit } from "../composables/useSuit";
+
+const props = withDefaults(defineProps<{ id?: string }>(), {
+  id: ''
+})
+const { state } = useAisWidget("autocomplete", props.id);
+
+const suit = useSuit("autocomplete");
+</script>

--- a/src/runtime/composables/useAisAutocomplete.ts
+++ b/src/runtime/composables/useAisAutocomplete.ts
@@ -1,0 +1,30 @@
+import { connectAutocomplete } from "instantsearch.js/es/connectors";
+import type {
+  AutocompleteConnectorParams,
+  AutocompleteRenderState,
+} from "instantsearch.js/es/connectors/autocomplete/connectAutocomplete";
+import type { Renderer } from "instantsearch.js/es/types";
+import { provide, ref } from "vue";
+
+export const useAisAutocomplete = (widgetParams: AutocompleteConnectorParams, id: string = "") => {
+  const stateRef = ref<AutocompleteRenderState | null>();
+  // 1. Create a render function
+  const renderAutocomplete: Renderer<
+    AutocompleteRenderState,
+    AutocompleteConnectorParams
+  > = (renderState, isFirstRender) => {
+    stateRef.value = renderState;
+    // render nothing, provide render state
+    if (isFirstRender) {
+      provide(`autocomplete-${id}`, stateRef);
+    }
+    // render nothing
+    return () => null;
+  };
+
+  // 2. Create the custom widget
+  const customAutocomplete = connectAutocomplete(renderAutocomplete);
+
+  // 3. Instantiate
+  return { ...customAutocomplete(widgetParams), $$widgetParams: widgetParams, $$widgetId: id };
+};


### PR DESCRIPTION
Really appreciate the effort to make better Nuxt3 search components!

I was missing the Autocomplete widget, so I ported it over as well. Based on the other code in this repo, I _think_ I've approached it in the same way as the others, but please let me know if there are any improvements to be made! Part of this is also a playground page for the autocomplete widget (`/autocomplete`), and it works pretty well it seems.

Hopefully we can merge this so I can keep building kickass searches!

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/atoms-studio/nuxt-swiftsearch/23)
<!-- GitContextEnd -->