### PR TITLE
feat: add AisRatingMenu component with usage documentation

### DIFF
--- a/docs/content/3.components/17.ais-rating-menu.md
+++ b/docs/content/3.components/17.ais-rating-menu.md
@@ -1,0 +1,61 @@
+---
+title: "<AisRatingMenu>"
+description: Rating Menu Widget
+---
+
+## Usage
+
+```vue [MySearchExperience.vue]
+<template>
+  <div>
+    <AisInstantSearch :widgets :configuration>
+      <AisRatingMenu attribute="rating" :max="5" />
+    </AisInstantSearch>
+  </div>
+</template>
+
+<script setup lang="ts">
+const widgets = computed(() => [
+  useAisRatingMenu({
+    attribute: "rating",
+    max: 5,
+  }),
+]);
+</script>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `attribute` | `string` | - | **Required.** The name of the attribute in the records |
+| `max` | `number` | `5` | The maximum rating value (number of stars) |
+
+## Features
+
+- **Visual Star Rating**: Displays ratings as filled (★) and empty (☆) stars
+- **Interactive Filtering**: Click on any rating to filter results
+- **Count Display**: Shows the number of results for each rating level
+- **Accessibility**: Proper semantic HTML structure with links
+
+## Example Output
+
+The component renders ratings in the format:
+- `★★★★☆ & Up (16074)` - 4+ star ratings
+- `★★★☆☆ & Up (17696)` - 3+ star ratings  
+- `★★☆☆☆ & Up (17890)` - 2+ star ratings
+- `★☆☆☆☆ & Up (18046)` - 1+ star ratings
+
+
+## Slots
+
+The component provides a default slot with the following props:
+
+- `items` - Array of rating items
+- `can-refine` - Boolean indicating if refinement is possible
+- `refine` - Function to refine by rating value
+- `create-u-r-l` - Function to create URLs for rating values
+- `send-event` - Function to send analytics events
+- `max` - Maximum rating value
+
+Slots, props and widget connector params are all typed!

--- a/playground/components/SearchExperience.vue
+++ b/playground/components/SearchExperience.vue
@@ -36,6 +36,7 @@
         searchable
       />
       <AisHierarchicalMenu attribute="hierarchicalCategories.lvl0" />
+      <AisRatingMenu attribute="rating" />
     </AisInstantSearch>
 
     <div @click="isFreeShipping = !isFreeShipping">
@@ -113,6 +114,9 @@ const widgets = computed(() => [
         };
       });
     },
+  }),
+  useAisRatingMenu({
+    attribute: "rating",
   }),
 ]);
 

--- a/src/runtime/components/RatingMenu.vue
+++ b/src/runtime/components/RatingMenu.vue
@@ -1,0 +1,68 @@
+<template>
+  <div
+    v-if="state"
+    :class="[suit(), !state.canRefine && suit('', 'noRefinement')]"
+  >
+    <slot
+      :items="state.items"
+      :can-refine="state.canRefine"
+      :refine="state.refine"
+      :create-u-r-l="state.createURL"
+      :send-event="state.sendEvent"
+      :max="max"
+    >
+      <ul :class="suit('list')">
+        <li
+          v-for="item in state.items"
+          :key="item.value"
+          :class="[suit('item'), item.isRefined && suit('item', 'selected')]"
+        >
+          <a
+            :href="state.createURL(item.value)"
+            :class="suit('link')"
+            @click.exact.left.prevent="state.refine(item.value)"
+          >
+            <span :class="suit('label')">{{ renderStars(Number(item.value), max ?? 5) }} & Up</span>
+            <span :class="suit('count')">({{ item.count }})</span>
+          </a>
+        </li>
+      </ul>
+    </slot>
+  </div>
+  <div v-else>
+    Rating Menu: No state available
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAisRatingMenuRenderState } from "../composables/useAisRatingMenu";
+import { useAisWidget } from "../composables/useAisWidget";
+import { useSuit } from "../composables/useSuit";
+import { computed } from "vue";
+
+const props = defineProps<{
+    attribute: string;
+    max?: number;
+}>();
+
+const suit = useSuit("Rating");
+const ratingMenuRenderState = useAisRatingMenuRenderState();
+const { state: ratingMenuState } = useAisWidget("ratingMenu");
+
+const state = computed(() => {
+  try {
+    return ratingMenuRenderState.value[props.attribute]
+      ? ratingMenuRenderState.value[props.attribute]
+      : ratingMenuState.value?.[props.attribute];
+  } catch (error) {
+    console.warn('RatingMenu: Error accessing state:', error);
+    return null;
+  }
+});
+
+const renderStars = (rating: number, max: number) => {
+  const filledStars = '★'.repeat(rating);
+  const emptyStars = '☆'.repeat(max - rating);
+  return filledStars + emptyStars;
+};
+</script>

--- a/src/runtime/composables/useAisRatingMenu.ts
+++ b/src/runtime/composables/useAisRatingMenu.ts
@@ -1,0 +1,39 @@
+import { connectRatingMenu } from "instantsearch.js/es/connectors";
+import type {
+  RatingMenuRenderState,
+  RatingMenuConnectorParams,
+} from "instantsearch.js/es/connectors/rating-menu/connectRatingMenu";
+import type { Renderer } from "instantsearch.js/es/types";
+import { useState } from "#app";
+import { provide, ref } from "vue";
+
+export const useAisRatingMenuRenderState = (key: string = "") =>
+  useState<Record<string, RatingMenuRenderState>>(
+    `ais_rating_menu_render_state${key}`,
+    () => ({})
+  );
+export const useAisRatingMenu = (
+  widgetParams: RatingMenuConnectorParams,
+  id: string = ""
+) => {
+  const stateRef = ref<RatingMenuRenderState | null>();
+  const ratingMenuRenderState = useAisRatingMenuRenderState(id);
+  const renderRatingMenu: Renderer<RatingMenuRenderState, RatingMenuConnectorParams> = (
+    renderState,
+    isFirstRender
+  ) => {
+    stateRef.value = renderState;
+    if (import.meta.client) {
+      ratingMenuRenderState.value[widgetParams.attribute] = renderState;
+    }
+    if (isFirstRender) {
+      provide(`ratingMenu-${id}`, stateRef);
+    }
+    return () => { };
+  };
+  const customConfigure = connectRatingMenu(renderRatingMenu);
+  return {
+    ...customConfigure(widgetParams),
+    $$widgetParams: widgetParams,
+  };
+};

--- a/src/runtime/composables/useInstantSearch.ts
+++ b/src/runtime/composables/useInstantSearch.ts
@@ -23,7 +23,7 @@ export const useInstantSearch = (instance?: Ref<InstantSearch> | null) => {
     (inject<Ref<InstantSearch | null>>("searchInstance") as Ref<InstantSearch>);
 
   const getInstance = () => {
-    if (_searchInstance!.value === null) {
+    if (!_searchInstance || _searchInstance.value === null) {
       throw new Error("instantiate instantsearch first");
     }
     return _searchInstance as Ref<InstantSearch>;


### PR DESCRIPTION
## Summary

Adds `AisRatingMenu` component to SwiftSearch for visual rating filters using stars.

## Features

- **Visual Star Rating**: Displays ratings as filled (★) and empty (☆) stars
- **Interactive Filtering**: Click any rating to filter results
- **Count Display**: Shows result count for each rating level

## Files Added

- `src/runtime/components/RatingMenu.vue` - Main component
- `src/runtime/composables/useAisRatingMenu.ts` - Widget logic
- `docs/content/3.components/17.ais-rating-menu.md` - Documentation

## Usage

```vue
<AisInstantSearch :widgets :configuration>
  <AisRatingMenu attribute="rating" :max="5" />
</AisInstantSearch>
```

## Output Format

- `★★★★☆ & Up (16074)` - 4+ stars
- `★★★☆☆ & Up (17696)` - 3+ stars
- `★★☆☆☆ & Up (17890)` - 2+ stars
- `★☆☆☆☆ & Up (18046)` - 1+ star

