### PR TITLE
feat: add AisQueryRuleCustomData component with usage documentation

### DIFF
--- a/docs/content/3.components/17.ais-query-rule-custom-data.md
+++ b/docs/content/3.components/17.ais-query-rule-custom-data.md
@@ -1,0 +1,78 @@
+---
+title: "<AisQueryRuleCustomData>"
+description: Query Rule Custom Data Widget
+---
+
+## Usage
+
+```vue [MyQueryRuleCustomData.vue]
+<template>
+  <div>
+    <AisInstantSearch
+      :widgets
+      :configuration
+    >
+      <AisIndex :index="indexName">
+        <AisConfigure
+          :rule-contexts.camel="['my-rule-context']"
+          query="my-query"
+        />
+        <AisQueryRuleCustomData>
+          <template #item="{ item }">
+            <div>
+              <a :href="item.link">
+                <img
+                  :src="item.banner"
+                  :alt="item.title"
+                >
+                <h2>{{ item.title }}</h2>
+                <p>{{ item.description }}</p>
+              </a>
+            </div>
+          </template>
+        </AisQueryRuleCustomData>
+      </AisIndex>
+    </AisInstantSearch>
+  </div>
+</template>
+
+<script setup lang="ts">
+import algoliasearch from "algoliasearch";
+import type { InstantSearchOptions } from "instantsearch.js/es/types";
+import { singleIndex as singleIndexMapping } from "instantsearch.js/es/lib/stateMappings";
+
+const client = algoliasearch("", "", {});
+const algoliaRouter = useAisRouter();
+
+const index = useAisIndex({
+  indexName: "airbnb",
+});
+
+index.addWidgets([useAisInfiniteHits({})]);
+const indexName = index.getIndexName();
+
+const widgets = computed(() => [
+  useAisQueryRuleCustomData({}),
+  useAisConfigure({
+    searchParameters: {
+      query: "my-query",
+      ruleContexts: ["my-rule-context"],
+    },
+  }),
+  index,
+]);
+
+const configuration = ref<InstantSearchOptions>({
+  indexName,
+  routing: {
+    router: algoliaRouter.value.router,
+    stateMapping: singleIndexMapping(indexName),
+  },
+  searchClient: client,
+} as unknown as InstantSearchOptions);
+</script>
+
+```
+
+Slots, props and widget connector params are all typed!
+More thorough documentation coming soon :)

--- a/src/runtime/components/AisQueryRuleCustomData.vue
+++ b/src/runtime/components/AisQueryRuleCustomData.vue
@@ -1,0 +1,30 @@
+<template>
+  <div :class="suit()">
+    <slot v-bind="{ items }">
+      <div
+        v-for="(item, index) in items"
+        :key="index"
+      >
+        <slot
+          name="item"
+          :item="item"
+        >
+          <div>{{ item }}</div>
+        </slot>
+      </div>
+    </slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAisWidget } from "../composables/useAisWidget";
+import { computed } from "vue";
+import { useSuit } from "../composables/useSuit";
+
+const { state } = useAisWidget("queryRules");
+const suit = useSuit("QueryRuleCustomData");
+
+const items = computed(() => {
+  return state.value?.items || [];
+});
+</script>

--- a/src/runtime/composables/useAisQueryRuleCustomData.ts
+++ b/src/runtime/composables/useAisQueryRuleCustomData.ts
@@ -1,0 +1,35 @@
+import { connectQueryRules } from "instantsearch.js/es/connectors";
+import type {
+  QueryRulesRenderState,
+  QueryRulesConnectorParams,
+} from "instantsearch.js/es/connectors/query-rules/connectQueryRules";
+import type { Renderer } from "instantsearch.js/es/types";
+import { provide, ref } from "vue";
+
+export const useAisQueryRuleCustomData = (
+  widgetParams: QueryRulesConnectorParams = {},
+  id: string = ""
+) => {
+  const stateRef = ref<QueryRulesRenderState | null>();
+
+  const renderQueryRules: Renderer<QueryRulesRenderState, QueryRulesConnectorParams> = (
+    renderState,
+    isFirstRender
+  ) => {
+    stateRef.value = renderState;
+
+    if (isFirstRender) {
+      provide(`queryRules-${id}`, stateRef);
+    }
+
+    return () => { };
+  };
+
+  const customQueryRules = connectQueryRules(renderQueryRules);
+
+  return {
+    ...customQueryRules(widgetParams),
+    $$widgetParams: widgetParams,
+    $$widgetId: id,
+  };
+};


### PR DESCRIPTION
## Summary

Adds `AisQueryRuleCustomData` component to SwiftSearch for rendering **Query Rule Custom Data** (`userData`) from Algolia Query Rules.

## Features

- **Custom Data Rendering**

## Files Added

- `src/runtime/components/QueryRuleCustomData.vue` – Main component  
- `src/runtime/composables/useAisQueryRuleCustomData.ts` – Widget logic  
- `docs/content/3.components/XX.ais-query-rule-custom-data.md` – Documentation  

## Note:

I couldn’t find a sample custom rule data in the example API to include in the Playground. I used a personal ID as an example instead, and I added the example to the `.md` docs. If you know the exact parameters to fetch the custom rule data, just let me know and I’ll add the component to the Playground :)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/atoms-studio/nuxt-swiftsearch/34)
<!-- GitContextEnd -->