### PR TITLE
Fix: add future attribute to playground to clean the console warnings

### DIFF
--- a/playground/components/SearchExperience.vue
+++ b/playground/components/SearchExperience.vue
@@ -123,6 +123,9 @@ const configuration = ref<InstantSearchOptions>({
     stateMapping: singleIndexMapping("instant_search"),
   },
   searchClient: client,
+  future: {
+    preserveSharedStateOnUnmount: true,
+  },
 } as unknown as InstantSearchOptions);
 type TProduct = {
   objectID: string;

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -112,6 +112,9 @@ const configuration = ref({
   indexName: "instant_search",
   routing: algoliaRouter.value,
   searchClient: client,
+  future: {
+    preserveSharedStateOnUnmount: true,
+  },
 });
 </script>
 


### PR DESCRIPTION
## Summary

Adds `future` attribute to the playground pages to avoid console warning issues