### PR TITLE
fix: remove lodash.isequal from optimizeDeps

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -39,7 +39,6 @@ export default defineNuxtModule<ModuleOptions>({
         "@algolia/events",
         "hogan.js",
         "qs",
-        "lodash.isequal",
       ],
     );
   },


### PR DESCRIPTION
`lodash.isequal` was recently removed in https://github.com/atoms-studio/nuxt-swiftsearch/commit/7b7dc3a2eedccfa111f1d93c7beb9be06b4dc1c0, but it was still included in `optimizeDeps`.

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/atoms-studio/nuxt-swiftsearch/42)
<!-- GitContextEnd -->