### PR TITLE
feat(useInstantSearch): expose reactive status and error refs

### DIFF
--- a/docs/content/3.components/34.ais-state-results.md
+++ b/docs/content/3.components/34.ais-state-results.md
@@ -1,0 +1,48 @@
+---
+title: AisStateResults
+description: Inspect search status, results, and errors with a render-prop slot.
+navigation:
+  icon: i-lucide-activity
+---
+
+`<AisStateResults>` exposes the current `<AisInstantSearch>` snapshot — `results`, `state`, `status`, `error` — to its default slot. Use it for loading indicators, empty-state UI, or debug overlays.
+
+It is not a connector widget; you don't need to register a `useAis*` factory in manual mode.
+
+## Usage
+
+```vue
+<AisInstantSearch :configuration="configuration">
+  <AisSearchBox />
+  <AisStateResults v-slot="{ status, error, results }">
+    <p v-if="status === 'stalled'">Searching…</p>
+    <p v-else-if="status === 'error'" class="error">{{ error?.message }}</p>
+    <p v-else-if="results?.nbHits === 0">No matches.</p>
+  </AisStateResults>
+  <AisHits />
+</AisInstantSearch>
+```
+
+## Slot bindings
+
+| Name      | Type                                                  | Description                                                                  |
+| --------- | ----------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `results` | `SearchResults \| null`                               | The latest results object for the parent `<AisIndex>` scope.                 |
+| `state`   | `SearchParameters \| null`                            | Helper state (refinements, query, page).                                     |
+| `status`  | `'idle' \| 'loading' \| 'stalled' \| 'error'`         | Reactive status. `stalled` only after `stalledSearchDelay` (default 200ms).  |
+| `error`   | `Error \| undefined`                                  | Last search error. Cleared on the next search.                               |
+
+## Props
+
+| Name         | Type         | Default     | Description                                                                                  |
+| ------------ | ------------ | ----------- | -------------------------------------------------------------------------------------------- |
+| `catchError` | `boolean`    | `false`     | Reserved for opting out of the default error throw on the client. Currently a no-op.         |
+| `errorFn`    | `() => void` | `undefined` | Reserved error handler.                                                                      |
+
+::note
+On SSR the first render lands in `idle` — results are pre-fetched and hydrated, so `loading` and `stalled` only fire on subsequent client-side searches.
+::
+
+## Related
+
+- [`useInstantSearch`](/composables/use-instant-search) — same `status`/`error` refs, accessible from any descendant component.

--- a/docs/content/4.composables/3.use-instant-search.md
+++ b/docs/content/4.composables/3.use-instant-search.md
@@ -10,14 +10,18 @@ navigation:
 ## Returned shape
 
 ```ts
-const { getInstance, parentIndex, setup } = useInstantSearch();
+const { getInstance, parentIndex, setup, status, error } = useInstantSearch();
 ```
 
 | Field         | Type                                              | Description                                                                                          |
 | ------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `getInstance` | `() => Ref<InstantSearch>`                        | Throws if the instance was not yet provided. Use it to access `helper`, `mainIndex`, `renderState`. |
+| `getInstance` | `() => Ref<InstantSearch>`                        | Throws if the instance was not yet provided. Use it to access `helper`, `mainIndex`, `renderState`.  |
 | `parentIndex` | `ComputedRef<IndexWidget>`                        | The instance's `mainIndex`. Useful when stitching `<AisIndex>` widgets manually.                     |
+| `status`      | `Ref<'idle' \| 'loading' \| 'stalled' \| 'error'>` | Reactive search status. `stalled` fires after `stalledSearchDelay` (default 200ms).                  |
+| `error`       | `Ref<Error \| undefined>`                         | Last search error. Cleared automatically when a new search starts.                                   |
 | `setup`       | `(widgets, instanceKey?) => Promise<void>`        | Internal — used by `<AisInstantSearch>` to register widgets and trigger SSR queries.                 |
+
+`status` and `error` are shared across every descendant call to `useInstantSearch()` within the same `<AisInstantSearch>`, so the same refs power `<AisStateResults>` and any custom loading UI you build.
 
 ## Usage
 
@@ -34,6 +38,37 @@ export const useTotalHits = () => {
   });
 };
 ```
+
+## Loading indicator example
+
+The reactive `status` ref makes [Algolia's loading-indicator pattern](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/loading-indicator/vue/) straightforward:
+
+```vue [components/SearchSpinner.vue]
+<script setup lang="ts">
+const { status } = useInstantSearch();
+</script>
+
+<template>
+  <div v-if="status === 'stalled'" class="spinner">Loading…</div>
+</template>
+```
+
+`stalled` only triggers after `stalledSearchDelay` (200ms by default), so the spinner stays hidden during fast queries. Pair it with `error` for inline failure UI:
+
+```vue
+<script setup lang="ts">
+const { status, error } = useInstantSearch();
+</script>
+
+<template>
+  <p v-if="status === 'stalled'">Searching…</p>
+  <p v-else-if="status === 'error'" class="error">{{ error?.message }}</p>
+</template>
+```
+
+::note
+On SSR the initial render lands directly in `idle` because results are pre-fetched and hydrated. The loading states only fire on subsequent client-driven searches (typing, refinement clicks, pagination, etc.).
+::
 
 ## Throwing behavior
 

--- a/src/runtime/components/StateResults.vue
+++ b/src/runtime/components/StateResults.vue
@@ -16,31 +16,24 @@
 <script setup lang="ts">
 import { useSuit } from "../composables/useSuit";
 import { useInstantSearch } from "../composables/useInstantSearch";
-import { computed, toRefs } from "vue";
+import { computed } from "vue";
 
-const { getInstance, parentIndex } = useInstantSearch();
+const { getInstance, parentIndex, status, error } = useInstantSearch();
 const suit = useSuit("StateResults");
 
-const props = withDefaults(defineProps<{ catchError?: boolean; errorFn?: () => void }>(), {
-  catchError: false,
-  errorFn: undefined,
-});
+defineProps<{ catchError?: boolean; errorFn?: () => void }>();
 
-const { catchError } = toRefs(props);
 const instance = getInstance();
 
-// custom state
 const state = computed(() => {
-  const status = instance.value.status;
-  const error = instance.value.error;
   const results = parentIndex.value.getResults();
   const helper = parentIndex.value.getHelper();
-  const state = helper ? helper.state : null;
   return {
     results,
-    state,
-    status,
-    error,
+    state: helper ? helper.state : null,
+    status: status!.value,
+    error: error!.value,
+    instance: instance.value,
   };
 });
 
@@ -50,19 +43,4 @@ const stateResults = computed(() => ({
   status: state.value.status,
   error: state.value.error,
 }));
-
-// TODO: handle errors
-// const noopErrorFn = () => {};
-//
-// watch(
-//   catchError,
-//   (shouldCatch) => {
-//     if (shouldCatch) {
-//       instance.value.addListener("error", noopErrorFn);
-//     } else if (props.errorFn) {
-//       instance.value.removeListener("error", noopErrorFn);
-//     }
-//   },
-//   { immediate: true },
-// );
 </script>

--- a/src/runtime/composables/useInstantSearch.ts
+++ b/src/runtime/composables/useInstantSearch.ts
@@ -1,15 +1,32 @@
-import type { IndexWidget, InstantSearch, Widget } from "instantsearch.js/es/types";
+import type {
+  IndexWidget,
+  InstantSearch,
+  InstantSearchStatus,
+  Widget,
+} from "instantsearch.js/es/types";
 import { isEqual } from "ohash";
 import { waitForResults, getInitialResults } from "instantsearch.js/es/lib/server";
 import { clearRefinements, getRefinements } from "instantsearch.js/es/lib/utils";
-import { computed, triggerRef, inject, nextTick, type Ref } from "vue";
+import { computed, inject, nextTick, provide, shallowRef, triggerRef, type Ref } from "vue";
 import { useState, createError } from "nuxt/app";
 
 import { type InitialResults } from "instantsearch.js/es";
 
+const STATUS_KEY = "swiftsearchStatus";
+const ERROR_KEY = "swiftsearchError";
+
 export const useInstantSearch = (instance?: Ref<InstantSearch> | null) => {
   const _searchInstance =
     instance ?? (inject<Ref<InstantSearch | null>>("searchInstance") as Ref<InstantSearch>);
+
+  let status = inject<Ref<InstantSearchStatus> | null>(STATUS_KEY, null);
+  let error = inject<Ref<Error | undefined> | null>(ERROR_KEY, null);
+  if (!status || !error) {
+    status = shallowRef<InstantSearchStatus>("idle");
+    error = shallowRef<Error | undefined>(undefined);
+    provide(STATUS_KEY, status);
+    provide(ERROR_KEY, error);
+  }
 
   const getInstance = () => {
     if (!_searchInstance || _searchInstance.value === null) {
@@ -99,13 +116,16 @@ export const useInstantSearch = (instance?: Ref<InstantSearch> | null) => {
         });
       });
 
-      instance.value.on("error", ({ error }) => {
+      instance.value.on("error", ({ error: searchError }) => {
+        error!.value = searchError;
+        status!.value = "error";
         throw createError({
           statusCode: 500,
-          statusMessage: error,
+          statusMessage: searchError,
         });
       });
       instance.value.start();
+      attachStatusListeners(instance.value, status!, error!);
     }
   };
 
@@ -113,5 +133,49 @@ export const useInstantSearch = (instance?: Ref<InstantSearch> | null) => {
     getInstance,
     parentIndex,
     setup,
+    status,
+    error,
   };
+};
+
+type StatusInternals = {
+  __swiftsearchStatusAttached?: boolean;
+  __swiftsearchStallTimer?: ReturnType<typeof setTimeout> | null;
+};
+
+const attachStatusListeners = (
+  instance: InstantSearch,
+  status: Ref<InstantSearchStatus>,
+  error: Ref<Error | undefined>,
+) => {
+  const tagged = instance as InstantSearch & StatusInternals;
+  if (tagged.__swiftsearchStatusAttached) return;
+  tagged.__swiftsearchStatusAttached = true;
+
+  const helper = instance.mainHelper;
+  if (!helper) return;
+
+  const stalledDelay =
+    (instance as InstantSearch & { _stalledSearchDelay?: number })._stalledSearchDelay ?? 200;
+
+  const clearStallTimer = () => {
+    if (tagged.__swiftsearchStallTimer) {
+      clearTimeout(tagged.__swiftsearchStallTimer);
+      tagged.__swiftsearchStallTimer = null;
+    }
+  };
+
+  helper.on("search", () => {
+    error.value = undefined;
+    status.value = "loading";
+    clearStallTimer();
+    tagged.__swiftsearchStallTimer = setTimeout(() => {
+      if (status.value === "loading") status.value = "stalled";
+    }, stalledDelay);
+  });
+
+  helper.on("searchQueueEmpty", () => {
+    clearStallTimer();
+    if (status.value !== "error") status.value = "idle";
+  });
 };


### PR DESCRIPTION
## Summary

- Closes #25 — surfaces a reactive `status` and `error` from `useInstantSearch()` so the standard [Algolia loading-indicator pattern](https://www.algolia.com/doc/guides/building-search-ui/ui-and-ux-patterns/loading-indicator/vue/) finally works.
- `<AisStateResults>` now reads from those shared refs instead of a non-reactive read off `instance.value.status`.
- New `<AisStateResults>` doc page + loading-indicator example in `useInstantSearch` cover the new public API.

## Why

> I've been exploring ways to implement a loading indicator in my search experience […] I noticed that the status provided by ais-state-results always seems to be idle. — #25

Cause was reactivity, not SSR: `<AisStateResults>` computed off `instance.value.status` (a plain JS property), and the only `triggerRef` happened on `searchQueueEmpty → render` — by which point `status` was already back to `idle`. The `loading` / `stalled` window was invisible to Vue.

## Fix

`useInstantSearch()` now returns `status: Ref<InstantSearchStatus>` and `error: Ref<Error | undefined>`, shared across descendants via `provide`/`inject`. Listeners on `mainHelper`'s `search` / `searchQueueEmpty` and the instance's `error` event drive the transitions, with a stall timer matching `_stalledSearchDelay` (default 200ms). Listener attachment is guarded so widget changes don't double-register.

Additive, optional API surface — no breaking changes.

## Test plan

- [x] `bun run check` (lint + format + 25 vitest tests) passes
- [ ] Verify spinner appears on slow queries in playground (manual smoke; the existing parity tests don't cover transient status)
- [ ] Confirm `<AisStateResults>` slot shows non-`idle` values when typing in the search box

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/atoms-studio/nuxt-swiftsearch/50)
<!-- GitContextEnd -->