### PR TITLE
fix: scope widget useState cache by InstantSearch instanceKey

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.3"
+setups.@nuxt/test-utils="4.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.3.0
+
+[compare changes](https://github.com/atoms-studio/nuxt-swiftsearch/compare/v1.2.0...v1.3.0)
+
+### 🩹 Fixes
+
+- Use instantsearch.js ESM index.js after index.umd removal ([#52](https://github.com/atoms-studio/nuxt-swiftsearch/pull/52))
+- Formatting and linting ([3d99461](https://github.com/atoms-studio/nuxt-swiftsearch/commit/3d99461))
+- Linting ([a3671de](https://github.com/atoms-studio/nuxt-swiftsearch/commit/a3671de))
+
+### 🏡 Chore
+
+- **release:** V1.2.0 ([b51ca72](https://github.com/atoms-studio/nuxt-swiftsearch/commit/b51ca72))
+
+### ❤️ Contributors
+
+- Rigo-m ([@Rigo-m](http://github.com/Rigo-m))
+- Alireza Jahandideh ([@Youhan](http://github.com/Youhan))
+
 ## v1.2.0
 
 [compare changes](https://github.com/atoms-studio/nuxt-swiftsearch/compare/v1.1.0...v1.2.0)

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     ],
     "**/*.{json,md,yml,yaml,css,scss,html}": "oxfmt --write --no-error-on-unmatched-pattern"
   },
+  "packageManager": "bun@1.3.14",
   "changelog": {
     "repo": "github:atoms-studio/nuxt-swiftsearch"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atoms-studio/nuxt-swiftsearch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A tailor made implementation of algolia instantsearch for nuxt 4",
   "homepage": "https://github.com/atoms-studio/nuxt-swiftsearch#readme",
   "bugs": {

--- a/src/runtime/components/InstantSearch.vue
+++ b/src/runtime/components/InstantSearch.vue
@@ -37,6 +37,7 @@ if (import.meta.server) {
 }
 
 provide<Ref<InstantSearch>>("searchInstance", searchInstance);
+provide<string>("instanceKey", instanceKey);
 
 const { setup } = useInstantSearch(searchInstance);
 await setup(props.widgets ?? [], props.instanceKey);

--- a/src/runtime/composables/useAisWidget.ts
+++ b/src/runtime/composables/useAisWidget.ts
@@ -12,6 +12,7 @@ export const useAisWidget = <const TWidget extends keyof RenderState["string"]>(
 
   const maybeInjectedIndexName = inject<string | undefined>("index", undefined);
   const maybeInjectedIndexId = inject<string | undefined>("indexId", undefined);
+  const maybeInjectedInstanceKey = inject<string | undefined>("instanceKey", undefined);
 
   const indexScope = maybeInjectedIndexId ?? maybeInjectedIndexName ?? instance.value.indexName;
   const index = indexScope;
@@ -25,11 +26,17 @@ export const useAisWidget = <const TWidget extends keyof RenderState["string"]>(
       : ref(instance.value.renderState[index][widgetName]!)
   ) as TWidgetRenderState;
 
+  // Suffix the cache key with the InstantSearch instance key so widgets with
+  // the same widgetName + index + widgetId on different pages do not share
+  // Nuxt's app-level useState cache. provide/inject is already scoped to the
+  // component tree, but useState is global.
+  const instanceSuffix = maybeInjectedInstanceKey ? `-${maybeInjectedInstanceKey}` : "";
+
   // cache injected values on client via useState
   const state = import.meta.server
     ? _state
     : widgetId
-      ? useState(`${widgetName}-${indexScope}-${widgetId}`, () => _state)
+      ? useState(`${widgetName}-${indexScope}-${widgetId}${instanceSuffix}`, () => _state)
       : _state;
   watch(
     instance,

--- a/test/declarative-transform.test.ts
+++ b/test/declarative-transform.test.ts
@@ -278,7 +278,7 @@ const configuration = {
 `;
 
       const { code, warn } = await transform(source);
-      expect(warn, `transform warned for ${tag}`).toHaveBeenCalledTimes(0);
+      expect(warn).toHaveBeenCalledTimes(0);
 
       const alias = aliasFor(config.composable);
       // Each call site for this composable must include a 2nd arg referencing
@@ -286,7 +286,7 @@ const configuration = {
       const callPattern = new RegExp(
         String.raw`${alias}\((?:[^()]|\((?:[^()]|\([^()]*\))*\))*?,\s*"`,
       );
-      expect(code, `${tag} did not inject an id arg`).toMatch(callPattern);
+      expect(code).toMatch(callPattern);
     }
   });
 });

--- a/test/fixtures/parity/pages/swift/state-collision/a.vue
+++ b/test/fixtures/parity/pages/swift/state-collision/a.vue
@@ -1,0 +1,20 @@
+<template>
+  <div data-testid="page-a">
+    <NuxtLink data-testid="go-to-b" to="/swift/state-collision/b">Go to B</NuxtLink>
+    <AisInstantSearch :configuration="configuration" instance-key="state-collision-a">
+      <AisConfigure :search-parameters="{ hitsPerPage: 5 }" />
+      <AisRefinementList id="shared-list" attribute="brand" />
+    </AisInstantSearch>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { algoliasearch } from "algoliasearch";
+
+const searchClient = algoliasearch("latency", "6be0576ff61c053d5f9a3225e2a90f76");
+
+const configuration = {
+  indexName: "instant_search",
+  searchClient,
+};
+</script>

--- a/test/fixtures/parity/pages/swift/state-collision/b.vue
+++ b/test/fixtures/parity/pages/swift/state-collision/b.vue
@@ -1,0 +1,20 @@
+<template>
+  <div data-testid="page-b">
+    <NuxtLink data-testid="go-to-a" to="/swift/state-collision/a">Go to A</NuxtLink>
+    <AisInstantSearch :configuration="configuration" instance-key="state-collision-b">
+      <AisConfigure :search-parameters="{ hitsPerPage: 5 }" />
+      <AisRefinementList id="shared-list" attribute="brand" />
+    </AisInstantSearch>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { algoliasearch } from "algoliasearch";
+
+const searchClient = algoliasearch("latency", "6be0576ff61c053d5f9a3225e2a90f76");
+
+const configuration = {
+  indexName: "instant_search",
+  searchClient,
+};
+</script>

--- a/test/index-isolation.test.ts
+++ b/test/index-isolation.test.ts
@@ -40,6 +40,15 @@ describe("swiftsearch index isolation", async () => {
     const indexOne = page.getByTestId("index-1");
     const indexTwo = page.getByTestId("index-2");
 
+    await indexOne
+      .locator("input[type='checkbox']")
+      .first()
+      .waitFor({ state: "visible", timeout: 120000 });
+    await indexTwo
+      .locator("input[type='checkbox']")
+      .first()
+      .waitFor({ state: "visible", timeout: 120000 });
+
     await indexOne.locator("input[type='checkbox']").first().check();
     await page.waitForTimeout(300);
 

--- a/test/state-collision.test.ts
+++ b/test/state-collision.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { setup, createPage } from "@nuxt/test-utils/e2e";
+import { ensureNuxtBuild } from "./utils/prebuild";
+
+/* eslint-disable jest/valid-describe-callback */
+
+const PORT = 7783;
+const getTestUrl = (route: string) => `http://127.0.0.1:${PORT}${route}`;
+const fixtureRoot = fileURLToPath(new URL("./fixtures/parity", import.meta.url));
+
+describe("swiftsearch widget state collision across pages", async () => {
+  ensureNuxtBuild(fixtureRoot);
+
+  await setup({
+    rootDir: fixtureRoot,
+    browser: true,
+    server: true,
+    dev: false,
+    build: false,
+    nuxtConfig: {
+      nitro: {
+        output: {
+          dir: resolve(fixtureRoot, ".output"),
+        },
+      },
+    } as any,
+    port: PORT,
+  });
+
+  it("does not leak refinements between pages sharing the same widget id + index", async () => {
+    const page = await createPage("/");
+    await page.goto(getTestUrl("/swift/state-collision/a"), {
+      waitUntil: "hydration",
+      timeout: 60000,
+    });
+    await page.waitForLoadState("networkidle");
+
+    const pageA = page.getByTestId("page-a");
+    await pageA
+      .locator("input[type='checkbox']")
+      .first()
+      .waitFor({ state: "visible", timeout: 120000 });
+
+    await pageA.locator("input[type='checkbox']").first().check();
+    await page.waitForTimeout(400);
+
+    const selectedOnA = await pageA.locator(".ais-RefinementList-item--selected").count();
+    expect(selectedOnA).toBeGreaterThan(0);
+
+    // SPA navigate to page B — same widget id + same index but different instance key.
+    await page.getByTestId("go-to-b").click();
+    await page.waitForLoadState("networkidle");
+
+    const pageB = page.getByTestId("page-b");
+    await pageB
+      .locator("input[type='checkbox']")
+      .first()
+      .waitFor({ state: "visible", timeout: 120000 });
+    await page.waitForTimeout(400);
+
+    // Page B has its own AisInstantSearch instance — no refinement should be active here.
+    const selectedOnB = await pageB.locator(".ais-RefinementList-item--selected").count();
+    expect(selectedOnB).toBe(0);
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
Fixes #55.

## Summary
- Widget render-state refs are exchanged via `provide`/`inject` (component-tree scoped) — that part was already safe.
- The collision was on the client-side **Nuxt `useState` cache key** inside `useAisWidget`, which was global (`${widgetName}-${indexScope}-${widgetId}`). Two pages with the same widgetName + index + widgetId aliased to the same payload slot, so after SPA-navigating from page A to page B, B's `useAisWidget` re-read A's frozen ref from the payload instead of B's freshly-provided ref.
- Fix: `AisInstantSearch` now `provide()`s its `instanceKey` to descendants, and `useAisWidget` suffixes the `useState` key with it. When `instance-key` is not set, the key shape is unchanged.

## Test plan
- [x] Added `test/state-collision.test.ts` — adversarial e2e reproducing the bug: SPA-navigate A → B with the same `id="shared-list"` `<AisRefinementList>` on `instant_search`. Verified it fails on `main` (B inherits A's refinement) and passes after the fix.
- [x] Added `test/fixtures/parity/pages/swift/state-collision/{a,b}.vue` fixture pages with distinct `instance-key` values.
- [x] `bun run check` (lint + format + 26 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)