### PR TITLE
fix: track InstantSearch status via render event

### DIFF
--- a/src/runtime/composables/useInstantSearch.ts
+++ b/src/runtime/composables/useInstantSearch.ts
@@ -140,9 +140,15 @@ export const useInstantSearch = (instance?: Ref<InstantSearch> | null) => {
 
 type StatusInternals = {
   __swiftsearchStatusAttached?: boolean;
-  __swiftsearchStallTimer?: ReturnType<typeof setTimeout> | null;
 };
 
+// InstantSearch core maintains its own `status` and `error` on the instance and
+// emits a `render` event whenever they change. We mirror them into the injected
+// refs on every render. Listening to the helper's `search` event is unreliable
+// here: instantsearch.js drives normal queries through `searchOnlyWithDerivedHelpers`,
+// which only emits `search` on derived helpers — never on the main helper this
+// composable sees. That is why the status stayed permanently `idle` for
+// `AisStateResults` consumers (see issue #53).
 const attachStatusListeners = (
   instance: InstantSearch,
   status: Ref<InstantSearchStatus>,
@@ -152,30 +158,11 @@ const attachStatusListeners = (
   if (tagged.__swiftsearchStatusAttached) return;
   tagged.__swiftsearchStatusAttached = true;
 
-  const helper = instance.mainHelper;
-  if (!helper) return;
-
-  const stalledDelay =
-    (instance as InstantSearch & { _stalledSearchDelay?: number })._stalledSearchDelay ?? 200;
-
-  const clearStallTimer = () => {
-    if (tagged.__swiftsearchStallTimer) {
-      clearTimeout(tagged.__swiftsearchStallTimer);
-      tagged.__swiftsearchStallTimer = null;
-    }
+  const sync = () => {
+    status.value = instance.status;
+    error.value = instance.error;
   };
 
-  helper.on("search", () => {
-    error.value = undefined;
-    status.value = "loading";
-    clearStallTimer();
-    tagged.__swiftsearchStallTimer = setTimeout(() => {
-      if (status.value === "loading") status.value = "stalled";
-    }, stalledDelay);
-  });
-
-  helper.on("searchQueueEmpty", () => {
-    clearStallTimer();
-    if (status.value !== "error") status.value = "idle";
-  });
+  sync();
+  instance.on("render", sync);
 };

--- a/test/fixtures/parity/pages/swift/state-results-status.vue
+++ b/test/fixtures/parity/pages/swift/state-results-status.vue
@@ -1,0 +1,41 @@
+<template>
+  <div data-testid="status-page">
+    <AisInstantSearch :configuration="configuration" instance-key="status-test">
+      <AisConfigure :search-parameters="{ hitsPerPage: 5 }" />
+      <AisRefinementList id="brand-list" attribute="brand" />
+      <AisStateResults v-slot="{ status }">
+        <div data-testid="status">{{ status }}</div>
+      </AisStateResults>
+    </AisInstantSearch>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { algoliasearch } from "algoliasearch";
+
+const baseClient = algoliasearch("latency", "6be0576ff61c053d5f9a3225e2a90f76");
+
+const SEARCH_DELAY_MS = 600;
+
+const delay = <T>(value: Promise<T>) =>
+  new Promise<T>((resolve, reject) => {
+    setTimeout(() => {
+      value.then(resolve, reject);
+    }, SEARCH_DELAY_MS);
+  });
+
+const searchClient = {
+  ...baseClient,
+  search(requests: Parameters<typeof baseClient.search>[0]) {
+    return delay(baseClient.search(requests));
+  },
+  searchForFacetValues(requests: Parameters<typeof baseClient.searchForFacetValues>[0]) {
+    return delay(baseClient.searchForFacetValues(requests));
+  },
+};
+
+const configuration = {
+  indexName: "instant_search",
+  searchClient,
+};
+</script>

--- a/test/state-results-status.test.ts
+++ b/test/state-results-status.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { setup, createPage } from "@nuxt/test-utils/e2e";
+import { ensureNuxtBuild } from "./utils/prebuild";
+
+/* eslint-disable jest/valid-describe-callback */
+
+const PORT = 7784;
+const getTestUrl = (route: string) => `http://127.0.0.1:${PORT}${route}`;
+const fixtureRoot = fileURLToPath(new URL("./fixtures/parity", import.meta.url));
+
+describe("AisStateResults status transitions during a slow search", async () => {
+  ensureNuxtBuild(fixtureRoot);
+
+  await setup({
+    rootDir: fixtureRoot,
+    browser: true,
+    server: true,
+    dev: false,
+    build: false,
+    nuxtConfig: {
+      nitro: {
+        output: {
+          dir: resolve(fixtureRoot, ".output"),
+        },
+      },
+    } as any,
+    port: PORT,
+  });
+
+  it("transitions to loading/stalled while a refinement-triggered search is in flight", async () => {
+    const page = await createPage("/");
+    await page.goto(getTestUrl("/swift/state-results-status"), {
+      waitUntil: "hydration",
+      timeout: 60000,
+    });
+    await page.waitForLoadState("networkidle");
+
+    const statusEl = page.getByTestId("status");
+    await statusEl.waitFor({ state: "visible", timeout: 120000 });
+
+    // After SSR + hydration the search has resolved, so we expect idle baseline.
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="status"]')?.textContent?.trim() === "idle",
+      null,
+      { timeout: 5000 },
+    );
+
+    const checkbox = page.getByTestId("status-page").locator("input[type='checkbox']").first();
+    await checkbox.waitFor({ state: "visible", timeout: 60000 });
+
+    // Trigger a new client-side search. The wrapped client delays each response
+    // by 600ms, which is well above the default 200ms stalled threshold, so the
+    // status must transition through loading/stalled before settling back to idle.
+    await checkbox.check();
+
+    // Must transition to a non-idle status while the search is in flight.
+    await page.waitForFunction(
+      () => {
+        const text = document.querySelector('[data-testid="status"]')?.textContent?.trim();
+        return text === "loading" || text === "stalled";
+      },
+      null,
+      { timeout: 1500 },
+    );
+    const inFlightStatus = (await statusEl.textContent())?.trim();
+    expect(inFlightStatus).toMatch(/loading|stalled/);
+
+    // Eventually returns to idle once the slow search completes.
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="status"]')?.textContent?.trim() === "idle",
+      null,
+      { timeout: 5000 },
+    );
+    const settledStatus = (await statusEl.textContent())?.trim();
+    expect(settledStatus).toBe("idle");
+
+    await page.close();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #53 — `status` in `AisStateResults` was always `idle`.

`useInstantSearch` was listening on `mainHelper.on("search")` to flip status to `loading`/`stalled`. But `instantsearch.js` drives normal queries via `searchOnlyWithDerivedHelpers`, which (per `algoliasearch-helper/src/algoliasearch.helper.js` line 1611) only emits `search` on derived helpers — never on the main helper this composable observes. So the listener never fired and status stayed `idle` forever, exactly as the reporter saw under 3G throttling.

The InstantSearch core already maintains its own `status` / `error` and emits a `render` event whenever either changes. Mirror those onto the injected refs and drop the redundant local stall timer.

## Test plan

- [x] New `test/state-results-status.test.ts` — wraps the search client to delay every response by 600ms, then asserts that toggling a refinement drives `AisStateResults`'s status through `loading`/`stalled` before settling back to `idle`. Confirmed Red on `main` (status text stays `idle`, `waitForFunction` times out at 1500ms) and Green after the fix.
- [x] `bun run check` (lint + format + 27 tests across 9 files) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)